### PR TITLE
docs: update getting start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [Overview](#overview)
 - [Requirements](#requirements)
 - [Installation Options](#installation-options)
-- [Getting Started](#getting-started)
+- [Getting Started](#getting-started-tutorial)
 - [Generator Options](#generator-options)
 - [Development and Testing](#development-and-testing)
 - [Legacy Exec Plugin](#legacy-exec-plugin)


### PR DESCRIPTION
Update README.me to fix Getting Start link on content summary